### PR TITLE
docs: run develop change port

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ npm run dev
 yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:4321](http://localhost:4321) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:4321/api/hello). This endpoint can be edited in `pages/api/hello.js`.
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 


### PR DESCRIPTION
## Issue reference: Documentation has wrong the app port

The server configuration has been updated to change the port from 3000 to 4321, as it is not running on port 300.This change helps prevent conflicts for collaborators who need to use the project.

## What has changed:

## What reviewers should know:

## Preview

<img width="634" alt="image" src="https://github.com/user-attachments/assets/c635aff2-817e-439e-b5d2-43c6beb5aa18">

