### PR TITLE
fix: change position and size of the gradient

### DIFF
--- a/src/components/gradientBackground.astro
+++ b/src/components/gradientBackground.astro
@@ -12,7 +12,7 @@ const { className } = Astro.props;
 
 <section class={cn(className, 'absolute pointer-events-none h-screen w-full -z-10 container left-0 right-0 mx-auto hidden lg:block')}>
   <div class={cn(classes.circles, classes.yellow, 'w-[770px]  h-[617px] top-[-10%] left-[-15%]  opacity-30')}></div>
-  <div class={cn(classes.circles, classes.orange, 'w-[1000px] h-[927px] top-[25%]  right-[-30%] opacity-40 hidden md:block')}></div>
+  <div class={cn(classes.circles, classes.orange, 'w-[900px] h-[927px] top-[25%]  right-[-16%] opacity-40 hidden md:block')}></div>
   <div class={cn(classes.circles, classes.yellow, 'w-[400px]  h-[400px] top-[75%]  left-[-20%]  opacity-30 hidden md:block')}></div>
   <div class={cn(classes.circles, classes.orange, 'w-[800px]  h-[800px] top-[105%] left-[15%]   opacity-30 hidden md:block')}></div>
   <div class={cn(classes.circles, classes.yellow, 'w-[300px]  h-[300px] top-[170%] left-[-15%]  opacity-80 hidden md:block')}></div>


### PR DESCRIPTION
## Issue reference: Gradient off bound

Removing the overflow-x-hidden property into body element we can see how the gradiente background move the site to right position so, I reduce the size and move the element according to the center page.

## What has changed:

I change the properties for the gradiente thus:

- from: w-[1000px] to w-[900px]
- from: right-[-30%] to right-[-16%]

## What reviewers should know:

tested on:
- macbook 13"
- screen 2048x2200

## Preview

before
![image](https://github.com/user-attachments/assets/33bc0340-7b77-496c-ad9d-eeeefd5cdfe2)


after
![image](https://github.com/user-attachments/assets/881999a8-86e5-4b87-bcd9-80504f2784a4)
